### PR TITLE
Sequence errors, timing, and coils turning on

### DIFF
--- a/AOMs-Coils.py
+++ b/AOMs-Coils.py
@@ -149,7 +149,8 @@ class AOMsCoils(EnvExperiment):
                 self.turn_on_AOMs()
 
     @kernel
-    def hardware_init_and_coils(self):
+    def aoms_and_coils(self):
+        self.base.initialize_hardware()
         self.turn_on_AOMs()
 
         if self.disable_coils:
@@ -161,5 +162,5 @@ class AOMsCoils(EnvExperiment):
                 channels=self.coil_channels)
 
     def run(self):
-        self.hardware_init_and_coils()
+        self.aoms_and_coils()
         self.run_feedback()

--- a/AtomLoadingOptimizerMLOOP.py
+++ b/AtomLoadingOptimizerMLOOP.py
@@ -202,8 +202,7 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
 
         self.core.reset()
 
-        self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
-                             channels=self.coil_channels)
+        delay(1*ms)
 
         self.dds_cooling_DP.sw.on()
         self.dds_AOM_A1.sw.on()
@@ -222,6 +221,10 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
         for i in range(10):
             self.laser_stabilizer.run()
         self.dds_FORT.sw.on()
+
+        delay(1*ms)
+        self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
+                             channels=self.coil_channels)
 
 
     def get_cost(self, data: TArray(TFloat,1)) -> TInt32:

--- a/AtomLoadingOptimizerMLOOP.py
+++ b/AtomLoadingOptimizerMLOOP.py
@@ -120,8 +120,9 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
                          broadcast=True)
 
         self.cost_dataset = "cost"
+        self.current_best_cost = 0
         self.set_dataset(self.cost_dataset,
-                         [0.0],
+                         [self.current_best_cost],
                          broadcast=True)
 
         # instantiate the M-LOOP interface
@@ -297,7 +298,18 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
 
         cost = self.get_cost(self.counts_list)
         self.append_to_dataset(self.cost_dataset, cost)
-
+        if cost < self.current_best_cost:
+            self.current_best_cost = cost
+            self.set_dataset("best params", params)
+            self.print_async("NEW BEST COST:", cost)
+            if self.tune_beams:
+                for i in range(4):
+                    self.print_async("BEST setpoint",i+1,print(self.default_setpoints[i] * setpoint_multipliers[i]))
+                if not self.disable_z_beam_tuning:
+                    self.print_async("BEST setpoint", 5, print(self.default_setpoints[4] * setpoint_multipliers[4]))
+                    self.print_async("BEST setpoint", 6, print(self.default_setpoints[5] * setpoint_multipliers[5]))
+            if self.tune_coils:
+                self.print_async("BEST coil values:", params[:4])
         return cost
 
 

--- a/AtomLoadingOptimizerMLOOP.py
+++ b/AtomLoadingOptimizerMLOOP.py
@@ -222,9 +222,9 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
             self.laser_stabilizer.run()
         self.dds_FORT.sw.on()
 
-        delay(1*ms)
-        self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
-                             channels=self.coil_channels)
+        # delay(1*ms)
+        # self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
+        #                      channels=self.coil_channels)
 
 
     def get_cost(self, data: TArray(TFloat,1)) -> TInt32:
@@ -265,10 +265,6 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
         else:
             setpoint_multipliers = params
 
-        if self.tune_coils:
-            self.zotino0.set_dac(self.coil_values, channels=self.coil_channels)
-            delay(1 * ms)
-
         if self.tune_beams:
             self.stabilizer_AOM_A1.set_point = self.default_setpoints[0] * setpoint_multipliers[0]
             self.stabilizer_AOM_A2.set_point = self.default_setpoints[1] * setpoint_multipliers[1]
@@ -282,6 +278,9 @@ class AtomLoadingOptimizerMLOOP(EnvExperiment):
                 self.laser_stabilizer.run()
         else:
             self.laser_stabilizer.run()
+
+        if self.tune_coils:
+            self.zotino0.set_dac(self.coil_values, channels=self.coil_channels)
 
         delay(1 * ms)
 

--- a/MOT_experiments/SamplerMOTCoilAndBeamBalanceTune.py
+++ b/MOT_experiments/SamplerMOTCoilAndBeamBalanceTune.py
@@ -126,9 +126,6 @@ class SamplerMOTCoilAndBeamBalanceTune(EnvExperiment):
 
         delay(1*ms)
 
-        self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
-                             channels=self.coil_channels)
-
         if self.FORT_AOM_on:
             self.dds_FORT.sw.on()
 
@@ -142,6 +139,9 @@ class SamplerMOTCoilAndBeamBalanceTune(EnvExperiment):
             self.laser_stabilizer.run(monitor_only=self.monitor_only)
             if self.FORT_AOM_on:
                 self.dds_FORT.sw.on()
+
+        self.zotino0.set_dac([self.AZ_bottom_volts_MOT, self.AZ_top_volts_MOT, self.AX_volts_MOT, self.AY_volts_MOT],
+                             channels=self.coil_channels)
 
         saturated_coils = [False] * 4
         control_volts = [0.0] * 4

--- a/subroutines/aom_feedback.py
+++ b/subroutines/aom_feedback.py
@@ -162,7 +162,7 @@ stabilizer_dict = {
                 {
                     'sampler_ch': 6, # the channel connected to the appropriate PD
                     'set_point': 'set_point_FORT_MM',
-                    'p': 0.7, #
+                    'p': 0.4, # set to 0.7 if using VCA
                     'i': 0.0, # the integral coefficient
                     'series': True, # setting to True because there's a bug with parallel
                     'dataset':'FORT_monitor',

--- a/subroutines/aom_feedback.py
+++ b/subroutines/aom_feedback.py
@@ -511,6 +511,7 @@ class AOMPowerStabilizer:
         if defaults_at_start:
             for ch in self.all_channels:
                 ch.set_dds_to_defaults()
+                delay(0.1 * ms)
 
         with sequential:
 
@@ -576,8 +577,9 @@ class AOMPowerStabilizer:
                     if self.exp.Luca_trigger_for_feedback_verification:
                         self.exp.ttl6.pulse(5 * ms)
                         delay(60*ms)
-                    delay(0.1*ms)
+                    delay(1*ms)
                     ch.dds_obj.sw.off()
+
 
             # update the datasets with the last values if we have not already done so
             if not record_all_measurements:

--- a/subroutines/aom_feedback.py
+++ b/subroutines/aom_feedback.py
@@ -137,7 +137,7 @@ stabilizer_dict = {
                 {
                     'sampler_ch': 1, # the channel connected to the appropriate PD
                     'set_point': 'set_point_PD5_AOM_A5',
-                    'p': 0.05, # the proportionality constant
+                    'p': 0.07, # the proportionality constant
                     'i': 0.00, # the integral coefficient
                     'series': True,
                     'dataset':'MOT5_monitor',
@@ -149,7 +149,7 @@ stabilizer_dict = {
                 {
                     'sampler_ch': 2, # the channel connected to the appropriate PD
                     'set_point': 'set_point_PD6_AOM_A6', # volts
-                    'p': 0.05, # the proportionality constant
+                    'p': 0.08, # the proportionality constant
                     'i': 0.00, # the integral coefficient
                     'series': True,
                     'dataset': 'MOT6_monitor',
@@ -494,6 +494,7 @@ class AOMPowerStabilizer:
         self.exp.core.reset()
 
         # self.exp.ttl7.pulse(1*ms) # scope trigger
+        delay(100*ms)
 
         # todo: up-date the set points for all channels in case they have been changed since
         #  the stabilizer was instantiated. not sure how to do this since getattr can not be

--- a/utilities/BaseExperiment.py
+++ b/utilities/BaseExperiment.py
@@ -290,8 +290,6 @@ class BaseExperiment:
         self.experiment.sampler1.init() # for reading laser feedback
         self.experiment.sampler2.init() # for reading laser feedback
 
-        self.experiment.print_async("base initialize_hardware - done")
-
         # turn on/off any switches. this ensures that switches always start in a default state,
         # which might not happen if we abort an experiment in the middle and don't reset it
         delay(1*ms)
@@ -300,25 +298,21 @@ class BaseExperiment:
         self.experiment.ttl_microwave_switch.on() # blocks the microwaves after the mixer
         delay(1*ms)
         self.experiment.ttl_SPCM_gate.off() # unblocks the SPCM output
-
+        #
         # turn off all dds channels
-        for ch in self.experiment.all_dds_channels:
-            ch.sw.off()
-
-        # check that the SPCM is plugged in #todo add other SPCM channels as they are added to the experiment
-        self.experiment.dds_FORT.sw.on() # we'll get enough Raman scattering to see something
-        delay(100*ms)
-        t_gate_end = self.experiment.ttl_SPCM0.gate_rising(100*ms)
-        counts = self.experiment.ttl_SPCM0.count(t_gate_end)
-        delay(10 * ms)
-        self.experiment.dds_FORT.sw.off()
-
-        # assert counts > 0, "SPCM0 is likely unplugged"
+        for dds_ch in self.experiment.all_dds_channels:
+            dds_ch.sw.off()
 
         # todo: turn off all Zotino channels?
+        self.experiment.zotino0.init()
+        for zot_ch in range(32):
+            self.experiment.zotino0.write_dac(zot_ch, 0.0)
+            self.experiment.zotino0.load()
+            delay(1*ms)
+
+        self.experiment.core.break_realtime()
 
         self.experiment.print_async("initialize hardware - done")
-        self.experiment.core.break_realtime()
 
 # do this so the code above will not actually run when ARTIQ scans the repository
 if __name__ == '__main__':

--- a/utilities/BaseExperiment.py
+++ b/utilities/BaseExperiment.py
@@ -105,7 +105,6 @@ class BaseExperiment:
         self.experiment.ttl_SPCM_gate = self.experiment.ttl13
 
 
-
         # initialize named channels.
         self.experiment.named_devices = DeviceAliases(
             experiment=self.experiment,
@@ -227,7 +226,8 @@ class BaseExperiment:
             self.experiment.counts2_list = [0] * self.experiment.n_measurements
         except:
             # if this fails, your experiment probably didn't need it
-            logging.warn("experiment does not have variable n_measurements")
+            self.experiment.print_async("experiment does not have variable n_measurements")
+            # logging.warn("experiment does not have variable n_measurements")
 
         dds_feedback_list = eval(self.experiment.feedback_dds_list)
         slow_feedback_dds_list = eval(self.experiment.slow_feedback_dds_list)
@@ -279,8 +279,10 @@ class BaseExperiment:
         self.experiment.ttl14.output()
         self.experiment.ttl14.on()
 
+
         # for diagnostics including checking the performance of fast switches for SPCM gating
         self.experiment.ttl9.output()
+        delay(1 * ms)
         self.experiment.ttl9.off()
 
         self.experiment.ttl_UV.output()
@@ -292,16 +294,16 @@ class BaseExperiment:
 
         # turn on/off any switches. this ensures that switches always start in a default state,
         # which might not happen if we abort an experiment in the middle and don't reset it
-        delay(1*ms)
         self.experiment.ttl_repump_switch.off() # allow RF to get to the RP AOM
         delay(1*ms)
         self.experiment.ttl_microwave_switch.on() # blocks the microwaves after the mixer
         delay(1*ms)
         self.experiment.ttl_SPCM_gate.off() # unblocks the SPCM output
-        #
+
         # turn off all dds channels
         for dds_ch in self.experiment.all_dds_channels:
             dds_ch.sw.off()
+            delay(1*ms)
 
         # todo: turn off all Zotino channels?
         self.experiment.zotino0.init()

--- a/utilities/DeviceAliases.py
+++ b/utilities/DeviceAliases.py
@@ -98,7 +98,6 @@ class DeviceAliases:
         self.experiment.urukul1_cpld.init()
         self.experiment.urukul2_cpld.init()
         self.experiment.core.break_realtime()
-        self.experiment.zotino0.init()
 
         for i in range(len(self.dds_list)):
             self.dds_list[i].init()


### PR DESCRIPTION
This PR fixes a number of issues in which the MOT coils were not turning on because the scheduler was ignoring the set_dac call. We found that calling set_dac before laser_stabilizer.run was the source of the issue most of the time, which resulted in the Zotino outputs not being updated. Calling set_dac after laser_stabilizer calls resolved this, at least where we found the problem. 

Minor changes have also been made in BaseExperiment and DeviceAliases to get rid of sequence errors and collisions.

Lastly, a few minor changes have been made: the FORT p coefficient in aom_feedback.py has been adjusted to account for removal of the VCA which was previously installed on the output of the corresponding Urukul channel, and AtomLoadingOptimizerMLOOP now saved the current best cost and parameters to datasets.