### PR TITLE
Monitor dds powers

### DIFF
--- a/ExperimentCycler.py
+++ b/ExperimentCycler.py
@@ -75,6 +75,15 @@ class ExperimentCycler(EnvExperiment):
         self.set_dataset("photocount_bins", [50], broadcast=True)
         self.set_dataset("iteration", 0, broadcast=True)
 
+        self.set_dataset("feedbackchannels",
+                         [ch.name for ch in self.laser_stabilizer.all_channels],
+                         broadcast=True, persist=True)
+
+        value = 0.0
+        for ch_i in range(len(self.laser_stabilizer.all_channels)):
+            self.set_dataset(self.laser_stabilizer.all_channels[ch_i].dB_history_dataset,
+                             [self.initial_RF_dB_values[ch_i]], broadcast=True, persist=True)
+
     def reset_datasets(self):
         """
         set datasets that are redefined each iteration.

--- a/ExperimentCycler.py
+++ b/ExperimentCycler.py
@@ -82,7 +82,7 @@ class ExperimentCycler(EnvExperiment):
         value = 0.0
         for ch_i in range(len(self.laser_stabilizer.all_channels)):
             self.set_dataset(self.laser_stabilizer.all_channels[ch_i].dB_history_dataset,
-                             [self.initial_RF_dB_values[ch_i]], broadcast=True, persist=True)
+                             [float(self.initial_RF_dB_values[ch_i])], broadcast=True, persist=True)
 
     def reset_datasets(self):
         """

--- a/ExperimentCycler.py
+++ b/ExperimentCycler.py
@@ -76,7 +76,7 @@ class ExperimentCycler(EnvExperiment):
         self.set_dataset("iteration", 0, broadcast=True)
 
         self.set_dataset("feedbackchannels",
-                         [ch.name for ch in self.laser_stabilizer.all_channels],
+                         [ch.dB_dataset for ch in self.laser_stabilizer.all_channels],
                          broadcast=True, persist=True)
 
         value = 0.0

--- a/GeneralVariableScan.py
+++ b/GeneralVariableScan.py
@@ -136,6 +136,11 @@ class GeneralVariableScan(EnvExperiment):
         for var,val in self.override_ExperimentVariables_dict.items():
             self.set_dataset(var, val)
 
+        value = 0.0
+        for ch_i in range(len(self.laser_stabilizer.all_channels)):
+            self.set_dataset(self.laser_stabilizer.all_channels[ch_i].dB_history_dataset,
+                             [float(self.initial_RF_dB_values[ch_i])], broadcast=True, persist=True)
+
     def reset_datasets(self):
         """
         set datasets that are redefined each iteration.

--- a/applets/plot_retention_and_loading.py
+++ b/applets/plot_retention_and_loading.py
@@ -91,10 +91,8 @@ class XYPlot(pyqtgraph.PlotWidget):
                         self.setYRange(-0.0, 1.0, padding=0)
 
                         title = str(data[self.args.scan_vars][1])
-                        if title != '':
-                            self.setTitle(title)
+                        self.setTitle(title)
 
-                        #
                         if error is not None:
                             # See https://github.com/pyqtgraph/pyqtgraph/issues/211
                             if hasattr(error, "__len__") and not isinstance(error, np.ndarray):

--- a/applets/plot_xy_multichannel.py
+++ b/applets/plot_xy_multichannel.py
@@ -1,9 +1,10 @@
 """
 For plotting up to 10 numeric sequences, for example, the DDS RF power history
 
-python "C:\..\applets\plot_xy_multichannel.py" p_AOM_A1_history
---y2 p_AOM_A2_history --y3 p_AOM_A3_history --y4 p_AOM_A4_history --y5 p_AOM_A5_history --y6 p_AOM_A6_history
---y7 p_FORT_loading --pts MOT_beam_monitor_points --labels feedbackchannels
+Example usage: 
+python "C:\..\qn_artiq_routines\applets\plot_xy_multichannel.py"
+p_AOM_A1_history MOT_beam_monitor_points --y2 p_AOM_A2_history --y3 p_AOM_A3_history
+--y4 p_AOM_A4_history --y5 p_AOM_A5_history --y6 p_AOM_A6_history --y7 p_FORT_loading_history --labels feedbackchannels
 """
 
 import numpy as np

--- a/subroutines/aom_feedback.py
+++ b/subroutines/aom_feedback.py
@@ -221,6 +221,7 @@ class FeedbackChannel:
         self.value_normalized = 0.0 # self.value normalized to the set point
         self.dataset = dataset
         self.dB_dataset = dB_dataset # the name of the dataset that stores the dB RF power for the dds
+        self.dB_history_dataset = dB_dataset + str("_history")
         self.t_measure_delay = t_measure_delay
         self.error_history_arr = np.full(error_history_length,0.0)
         self.error_buffer = np.full(error_history_length-1,0.0)
@@ -449,7 +450,8 @@ class AOMPowerStabilizer:
         self.all_channels = self.parallel_channels + self.series_channels
 
         # for logging the measured voltages
-        for ch in self.all_channels: # todo: update with the last value from the dataset
+
+        for ch in self.all_channels:
             try:
                 self.exp.set_dataset(ch.dataset, [self.exp.get_dataset(ch.dataset)[-1]], broadcast=True)
             except Exception as e:
@@ -465,6 +467,7 @@ class AOMPowerStabilizer:
         for ch in self.all_channels:
             dB = 10*(np.log10(ch.amplitude**2/(2*50)) + 3)
             self.exp.set_dataset(ch.dB_dataset, dB, broadcast=True, persist=True)
+            self.exp.append_to_dataset(ch.dB_history_dataset, dB)
 
     @kernel
     def measure(self):


### PR DESCRIPTION
This PR adds dataset creation (in BaseExperient) and modification (in AOMPowerStabilizer) for storing the history of RF power datasets for FeedbackChannels over the course of an experiment, as well as tweaks to the applet plot_xy_multichannel.py for ease of plotting these or other multichannel data.