### PR TITLE
Release recapture fitting code

### DIFF
--- a/fitting/networklab_release_recap_fitting_example.py
+++ b/fitting/networklab_release_recap_fitting_example.py
@@ -1,0 +1,27 @@
+"""
+example usage for the temp fitting code
+"""
+
+# import the fitting functions
+sys.path.append("C:\\..\\qn_artiq_routines")
+from fitting.run_modeling import get_release_recap_fit_result, release_recap_retention_at_t
+
+# define trap params
+trap_params = {'Tdepth': 2e-3, 'wx': 0.8e-6, 'lmda': 8.52e-7}
+
+# get the fit result for temp (K) and retention, and the retention points for the fit at each timestep.
+# pass in the time steps (us), retention, and a guess for the temp (uK) and baseline_retention
+popt, fit_retention = get_release_recap_fit_result(t_steps_us, retention, p0=[temp_guess_uK,baseline_retention_guess], 
+                                                   retention_at_t_kwargs=trap_params)
+                                                   
+# generate a temp curve with more timesteps since we typically don't have more than a few timesteps for the data
+hi_res_t_steps_us = np.linspace(0, 100, 100)
+fit_retention_hi_res = release_recap_retention_at_t(hi_res_t_steps_us, T=popt[0], base_retention=popt[1], **trap_params)
+
+fig, ax = plt.subplots()
+ax_ret.scatter(t_steps_us, retention)
+ax_ret.errorbar(t_steps_us, retention, errs, ls='none')
+ax.plot(hi_res_t_steps_us, fit_retention_hi_res, label=f'fit: T={popt[0]*1e6:.2f} uK, r={popt[1]:.2f}',
+            linestyle='dashdot')
+
+

--- a/fitting/run_modeling.py
+++ b/fitting/run_modeling.py
@@ -1,6 +1,7 @@
 #### libraries
 # np.seterr(all='raise') # raise errors, don't just print warnings
 from numpy import *
+import numpy as np
 from numpy.random import normal
 from scipy.optimize import curve_fit
 from random import random as rand

--- a/fitting/run_modeling.py
+++ b/fitting/run_modeling.py
@@ -1,5 +1,7 @@
-#### libraries
-# np.seterr(all='raise') # raise errors, don't just print warnings
+"""
+
+"""
+
 from numpy import *
 import numpy as np
 from numpy.random import normal
@@ -12,23 +14,30 @@ from utilities.physics.rbconsts import *
 from utilities.physics.rbensemble import RbEnsemble as ensemble
 
 
-def retention_at_t(t, T=None, base_retention=0.9, Tdepth = 1e-3, wx = 0.7e-6, wy =0.7e-6, lmda = 8.52e-7):
+def release_recap_retention_at_t(t, T, base_retention, Tdepth=1e-3, wx=0.7e-6, wy=None, lmda=8.52e-7, events=1000):
         """ Procedure for simulating a release ("drop") and recapture experiment
-            to deduce the temperature of actual atoms in such an experiment.
+        to deduce the temperature of actual atoms in such an experiment.
 
-            Based on code by Mark, with some corrections
-            'wx': waist
-            'Tdepth': FORT temperature depth
-            'T': atom temp
-            'tmax': max time in units us
-            'steps': number of FORT drop outs
-            'events': number of release-recapture events per photocounts pt
-            'wy': optional waist for elliptical FORT
-            'lmda': optional wavelength of the FORT
+        Based on code by Mark, with some corrections
+        't': time at which to evaluate the simulation (us). can be scalar or 1D numpy array
+        'wx': waist
+        'Tdepth': FORT temperature depth (K)
+        'T': atom temp (K)
+        'tmax': max time in units us
+        'steps': number of FORT drop outs
+        'events': number of release-recapture events per photocounts pt
+        'wy': optional waist for elliptical FORT
+        'lmda': optional wavelength of the FORT
+
+        Note: the time entered in microseconds empirically gives a much more reliable fit value
+        compared to entering the values in seconds, likely due to precision loss somewhere.
         """
-        T = abs(T)
-        events = 20000
 
+        if wy is None:
+                wy = wx
+
+        # print(f"scipy is trying T={T*1e6:.2f}K, base_retention={base_retention:.2f}...")
+        # print(f"scipy is trying wx = {wx}, wy = {wy}, lmda = {lmda}, Tdepth = {Tdepth}, ")
         umax = kB * Tdepth
         zR = pi * wx ** 2 / lmda
 
@@ -71,7 +80,7 @@ def retention_at_t(t, T=None, base_retention=0.9, Tdepth = 1e-3, wx = 0.7e-6, wy
         if events is None:
                 events = 20000
         if base_retention is None:
-                base_retention = 1  #the retention baseline with no fort drop
+                base_retention = 1  # the retention baseline with no fort drop
 
         escape = float64(empty(len(t)))
 
@@ -92,23 +101,38 @@ def retention_at_t(t, T=None, base_retention=0.9, Tdepth = 1e-3, wx = 0.7e-6, wy
 
         retention = base_retention * (1 - escape / float64(events))
 
-        print(f"finished. T={T * 1e6} [uK], r = {base_retention}")
+        # print(f"finished. T={T * 1e6} [uK], r = {base_retention}")
 
         return retention
 
-def temp(tlist, retention, p0 = None):
-        if p0 == None:
-                p0 = [4e-5, retention[0], 1e-3, 0.7e-6, 0.7e-6]
+def get_release_recap_fit_result(tlist, retention, p0=None, bounds=None, retention_at_t_kwargs={}):
+        """
 
+        :param tlist:
+        :param retention:
+        :param p0:
+        :param bounds: array of 2-tuple of boundaries for temp in K and retention with 1st (2nd) tuple minima (maxima)
+        :param retention_at_t_kwargs: keyword arguments for release_recap_retention_at_t which is used as the model
+                for the fit. these arguments might specify, e.g., the trap parameters
+        :return: tuple of popt from curve_fit, y points from model evaluated with fit params
+        """
+        if p0 is None:
+                p0 = [4e-5, retention[0]]
+        if bounds is None:
+                lower_bounds = np.array([1e-7, 0.0])
+                upper_bounds = np.array([5e-4, 1.0])
+                bounds = (lower_bounds, upper_bounds)
 
-        popt, pcov = curve_fit(retention_at_t, tlist, retention, p0=p0, absolute_sigma=False,
-                                                   maxfev=1000000000, epsfcn=1)
+        model = lambda t, T, r: release_recap_retention_at_t(t, T, r, **retention_at_t_kwargs)
 
-        modeled_y = retention_at_t(tlist, *popt)
+        popt, pcov = curve_fit(model, tlist, retention, p0=p0, absolute_sigma=False, bounds=bounds,
+                               x_scale=(1e-6,1), diff_step=0.1)
+
+        modeled_y = release_recap_retention_at_t(tlist, *popt, **retention_at_t_kwargs)
         return popt, modeled_y
 
 
-def atom_loading_fit(xdata=None, p0 = None, bin_count = 40, measurements = 500):
+def atom_loading_fit(xdata=None, p0=None, bin_count=40, measurements=500):
         ret_args = {}
         print("Proceding with atom_loading_fit at time:", time.time())
         factor = 1 / 100
@@ -177,7 +201,7 @@ def atom_loading_fit(xdata=None, p0 = None, bin_count = 40, measurements = 500):
                 return ret_args
 
 
-def start_modeling(model = "temperature", args = None):
+def start_modeling(model = "temperature", args=None):
         starting_time = time.time()
         print(f"Attempting to run: {model} at {starting_time}")
 
@@ -187,7 +211,7 @@ def start_modeling(model = "temperature", args = None):
                 xdata should be time in terms of micro seconds
                 if p0 is not provided, p0 = (40(uK), retention[0], Tdepth = 1e-3, wx = 0.7e-6, wy =0.7e-6 )
                 """
-                ret_args = temp(*args)
+                ret_args = get_release_recap_fit_result(*args)
                 print(f"Completed: {model} after {(time.time() - starting_time)} seconds")
                 return ret_args
 

--- a/tests/AtomLoadingSimTest.py
+++ b/tests/AtomLoadingSimTest.py
@@ -1,5 +1,14 @@
 from artiq.experiment import *
 from scipy.stats import poisson
+import numpy as np
+
+import sys, os
+# get the current working directory
+cwd = os.getcwd() + "\\"
+sys.path.append(cwd)
+sys.path.append(cwd+"\\repository\\qn_artiq_routines")
+
+
 from fitting.run_modeling import *
 import matplotlib.pyplot as plt
 # a no-hardware simulation that we can use to test plotting

--- a/tests/AtomLoadingSimTest.py
+++ b/tests/AtomLoadingSimTest.py
@@ -166,7 +166,7 @@ class SingleAtomLoading(EnvExperiment):
         # NaNs only arise if the class is empty, in which case the contribution should be zero, which `nansum` accomplishes.
 class SingleAtomTest(EnvExperiment):
     """
-    Count Fiting
+    Count Fitting
     """
 
     def build(self):

--- a/tests/AtomTempTest.py
+++ b/tests/AtomTempTest.py
@@ -2,7 +2,12 @@ from artiq.experiment import *
 from numpy import *
 from collections import namedtuple
 
-#from utilities.dropsimulation import *
+import sys, os
+# get the current working directory
+cwd = os.getcwd() + "\\"
+sys.path.append(cwd)
+sys.path.append(cwd+"\\repository\\qn_artiq_routines")
+
 from fitting.run_modeling import *
 class AtomExperimentSim(EnvExperiment):
     """
@@ -31,11 +36,8 @@ class AtomExperimentSim(EnvExperiment):
         self.set_dataset("tlist", tlist, broadcast=True)
         self.set_dataset("ret_1", reten_1, broadcast=True)
 
-
         if p0 == None:
            p0 = [4.e-5, 0.95]
-
-
 
         TLIST = linspace(0, 160, 20)  # time [us]
         R1 = retention_at_t(TLIST, 5e-5, base_retention=0.90)

--- a/tests/AtomTempTest.py
+++ b/tests/AtomTempTest.py
@@ -1,3 +1,10 @@
+"""
+An experiment to test Jake Uribe's release recapture temperature fitting code
+
+Runs a Monte-Carlo simulation to generate simulated data for a given atom temp and hardcoded trap params, then
+fits the simulated data to the Monte Carlo simulation to extract a temperature and baseline retention.
+"""
+
 from artiq.experiment import *
 from numpy import *
 from collections import namedtuple
@@ -9,6 +16,8 @@ sys.path.append(cwd)
 sys.path.append(cwd+"\\repository\\qn_artiq_routines")
 
 from fitting.run_modeling import *
+
+
 class AtomExperimentSim(EnvExperiment):
     """
     Atom Temp Test
@@ -20,45 +29,42 @@ class AtomExperimentSim(EnvExperiment):
         self.setattr_argument("measurements", NumberValue(42, step=1))
         self.setattr_argument("bins", NumberValue(42, step=1))
         self.setattr_argument("bin width", NumberValue(42, step=1))
-        self.setattr_argument("temp", NumberValue(40.0, step = 0.25))
+        self.setattr_argument("atom_temp_uK", NumberValue(50.0, step=0.25))
+        self.setattr_argument("atom_temp_guess_uK", NumberValue(50.0, step=0.25))
+        self.setattr_argument("atom_retention_guess", NumberValue(0.95, step=0.25))
+
 
     def run(self):
         w0 = 2.5e-6  # [m]
         TFORT = 1.5e-3  # [K]
-        Tatom = 5e-5
-        steps = 100
-        tlist = linspace(0, steps, steps)  # time [us]
-        p0 = None
+        FORT_lmbda = 8.52e-7 # [m]
+        tlist = array([1, 2, 5, 10, 15, 20, 50, 75, 100, 150])  # [us]
 
-        reten_1 = retention_at_t(tlist, Tatom, base_retention=.95, Tdepth=TFORT, wx = w0, wy = w0)
+        trap_params = {'Tdepth': TFORT, 'wx': w0, 'lmda': FORT_lmbda}
 
+        model = lambda t, T, r: release_recap_retention_at_t(t, T, r, **trap_params)
+        simulated_retention = model(tlist, self.atom_temp_uK*1e-6 , 0.95)
 
         self.set_dataset("tlist", tlist, broadcast=True)
-        self.set_dataset("ret_1", reten_1, broadcast=True)
 
-        if p0 == None:
-           p0 = [4.e-5, 0.95]
+        p0 = [self.atom_temp_guess_uK*1e-6, self.atom_retention_guess]
 
-        TLIST = linspace(0, 160, 20)  # time [us]
-        R1 = retention_at_t(TLIST, 5e-5, base_retention=0.90)
-        args = TLIST, R1, p0
+        trap_params = {'Tdepth': TFORT, 'wx': w0, 'lmda': FORT_lmbda}
+        popt, fit_retention = get_release_recap_fit_result(tlist, simulated_retention, p0, retention_at_t_kwargs=trap_params)
 
-        popt, modeled_r = self.model(args = args)
-        # 72 simulates count above threshold
-        sigma = ones((len(modeled_r))) / sqrt(72)
+        print(f"finished. fit: T={popt[0] * 1e6} [uK], r = {popt[1]}")
 
         self.set_dataset("optimal_temp_k", popt[0], broadcast=True)
         self.set_dataset("r_opt", popt[1], broadcast=True)
-        self.set_dataset("modeled_r", modeled_r, broadcast=True)
-        self.set_dataset("sigma", sigma, broadcast=True)
-        self.set_dataset("model_t_data", TLIST, broadcast=True)
-        self.set_dataset("model_ret_data", R1, broadcast=True)
+        self.set_dataset("fit_ret", fit_retention, broadcast=True)
 
-
+        # self.set_dataset("sigma", sigma, broadcast=True)
+        self.set_dataset("model_t_data", tlist, broadcast=True)
+        self.set_dataset("model_ret_data", simulated_retention, broadcast=True)
 
     def create_applet(self):
         return -1
 
-    def model(self, args = None):
-
-        return start_modeling("temperature", args)
+    # def model(self, args = None):
+    #
+    #     return start_modeling("temperature", args)


### PR DESCRIPTION
Incorporates release recapture fitting code largely written by @jaykeuribe. 

Retention data can be fit to a Monte Carlo simulation of a single atom release recapture experiment given parameters to describe the dipole trap (1/e^2 beam radius, depth in K, wavelength) and initial guesses for the atom temperature and baseline retention (i.e. the retention if there is no trap drop).