### PR TITLE
D1 double pass controlled in ARTIQ in place of D1 single pass.

### DIFF
--- a/AOMsCoils.py
+++ b/AOMsCoils.py
@@ -16,7 +16,7 @@ class AOMsCoils(EnvExperiment):
         self.setattr_argument("FORT_AOM_ON", BooleanValue(default=False))
         self.setattr_argument("Cooling_DP_AOM_ON", BooleanValue(default=False))
         self.setattr_argument("Repump_AOM_ON", BooleanValue(default=True))
-        self.setattr_argument("D1_pumping_SP_AOM_ON", BooleanValue(default=False))
+        self.setattr_argument("D1_pumping_DP_AOM_ON", BooleanValue(default=False))
         self.setattr_argument("pumping_repump_AOM_ON", BooleanValue(default=False))
         self.setattr_argument("excitation_AOM_ON", BooleanValue(default=False))
         self.setattr_argument("AOM_A1_ON", BooleanValue(default=False), "Fiber AOMs")
@@ -66,10 +66,10 @@ class AOMsCoils(EnvExperiment):
             self.ttl_repump_switch.on()
 
         delay(1 * ms)
-        if self.D1_pumping_SP_AOM_ON == True:
-            self.dds_D1_pumping_SP.sw.on()
+        if self.D1_pumping_DP_AOM_ON == True:
+            self.dds_D1_pumping_DP.sw.on()
         else:
-            self.dds_D1_pumping_SP.sw.off()
+            self.dds_D1_pumping_DP.sw.off()
 
         delay(1 * ms)
         if self.pumping_repump_AOM_ON == True:

--- a/ExperimentVariables.py
+++ b/ExperimentVariables.py
@@ -110,9 +110,9 @@ class ExperimentVariables(EnvExperiment):
                      "Cooling double pass AOM"),
 
             # D1 optical pumping, pumping repumper, and excitation
-            Variable("f_D1_pumping_SP", 90 * MHz, NumberValue, {'type': 'float', 'unit': 'MHz'},
+            Variable("f_D1_pumping_DP", 368.325 * MHz, NumberValue, {'type': 'float', 'unit': 'MHz', 'ndecimals': 1},
                      "OP and excitation AOMs"),
-            Variable("p_D1_pumping_SP", -9.0, NumberValue, {'type': 'float', 'unit': "dBm", 'scale': 1, 'ndecimals': 1},
+            Variable("p_D1_pumping_DP", -9.0, NumberValue, {'type': 'float', 'unit': "dBm", 'scale': 1, 'ndecimals': 1},
                      "OP and excitation AOMs"),
             Variable("f_pumping_repump", 345.10 * MHz, NumberValue, {'type': 'float', 'unit': 'MHz'},
                      "OP and excitation AOMs"),

--- a/MOT_experiments/MOTDetuningAndGradBScan.py
+++ b/MOT_experiments/MOTDetuningAndGradBScan.py
@@ -79,7 +79,7 @@ class MOTDetuningAndGradBScan(EnvExperiment):
         self.set_dataset("FORT_TTI_volts", [0.0])
 
         # turn off AOMs we aren't using, in case they were on previously
-        self.dds_D1_pumping_SP.sw.off()
+        self.dds_D1_pumping_DP.sw.off()
         self.dds_excitation.sw.off()
 
         # turn on cooling MOT AOMs and warm up FORT AOM

--- a/MOT_experiments/MonitorMOTandExternalBeamPositions.py
+++ b/MOT_experiments/MonitorMOTandExternalBeamPositions.py
@@ -74,7 +74,7 @@ class MonitorMOTandExternalBeamPositions(EnvExperiment):
         self.set_dataset("FORT_TTI_volts", [0.0])
 
         # turn off AOMs we aren't using, in case they were on previously
-        self.dds_D1_pumping_SP.sw.off()
+        self.dds_D1_pumping_DP.sw.off()
         self.dds_excitation.sw.off()
 
         # turn on cooling MOT AOMs and warm up FORT AOM

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A dictionary mapping aliases of the urukul channels and their defaults lives in 
     ALIAS_MAP = {
           "dds_FORT": "urukul0_ch0", # the key is the alias, and the value is the name given in device_db.py
           "dds_cooling_DP": "urukul0_ch1",
-          "dds_D1_pumping_SP": "urukul0_ch2",
+          "dds_D1_pumping_DP": "urukul0_ch2",
           ...
           "dds_AOM_A4": "urukul2_ch0",
           "dds_AOM_A5": "urukul2_ch1"
@@ -96,7 +96,7 @@ If you insist on importing the aliases "manually", use the block below to set th
             experiment=self.experiment,
             device_aliases=[ # the channels you want to use, which are already defined in ALIAS_MAP
                 'dds_FORT',
-                'dds_D1_pumping_SP',
+                'dds_D1_pumping_DP',
                 'dds_cooling_DP',
                 'dds_pumping_repump',
                 *[f'dds_AOM_A{i + 1}' for i in range(6)]  # the fiber AOMs

--- a/subroutines/aom_feedback.py
+++ b/subroutines/aom_feedback.py
@@ -155,7 +155,7 @@ class FeedbackChannel:
         measured = buffer[self.buffer_index]
         err = self.set_points[setpoint_index] - measured
 
-        if self.name == 'dds_D1_pumping_SP':
+        if self.name == 'dds_D1_pumping_DP':
             self.stabilizer.exp.print_async(measured, self.buffer_index, self.stabilizer.measurement_array)
 
         # runs off the kernel, else the error array isn't correctly updated

--- a/utilities/BaseExperiment.py
+++ b/utilities/BaseExperiment.py
@@ -235,9 +235,9 @@ class BaseExperiment:
             # converts RF power in dBm to amplitudes in V
             self.experiment.ampl_FORT_loading = dB_to_V(self.experiment.p_FORT_loading)
             self.experiment.ampl_cooling_DP_MOT = dB_to_V(self.experiment.p_cooling_DP_MOT)
-            self.experiment.ampl_D1_pumping_SP = dB_to_V(self.experiment.p_D1_pumping_SP)
+            self.experiment.ampl_D1_pumping_DP = dB_to_V(self.experiment.p_D1_pumping_DP)
             self.experiment.ampl_pumping_repump = dB_to_V(self.experiment.p_pumping_repump)
-            self.experiment.ampl_D1_pumping_SP = dB_to_V(self.experiment.p_D1_pumping_SP)
+            self.experiment.ampl_D1_pumping_DP = dB_to_V(self.experiment.p_D1_pumping_DP)
             self.experiment.ampl_excitation = dB_to_V(self.experiment.p_excitation)
             self.experiment.ampl_microwaves = dB_to_V(self.experiment.p_microwaves)
             self.experiment.ampl_AOM_A1 = dB_to_V(self.experiment.p_AOM_A1)
@@ -308,9 +308,9 @@ class BaseExperiment:
             # converts RF power in dBm to amplitudes in V
             self.experiment.ampl_FORT_loading = dB_to_V(self.experiment.p_FORT_loading)
             self.experiment.ampl_cooling_DP_MOT = dB_to_V(self.experiment.p_cooling_DP_MOT)
-            self.experiment.ampl_D1_pumping_SP = dB_to_V(self.experiment.p_D1_pumping_SP)
+            self.experiment.ampl_D1_pumping_DP = dB_to_V(self.experiment.p_D1_pumping_DP)
             self.experiment.ampl_pumping_repump = dB_to_V(self.experiment.p_pumping_repump)
-            self.experiment.ampl_D1_pumping_SP = dB_to_V(self.experiment.p_D1_pumping_SP)
+            self.experiment.ampl_D1_pumping_DP = dB_to_V(self.experiment.p_D1_pumping_DP)
             self.experiment.ampl_excitation = dB_to_V(self.experiment.p_excitation)
             self.experiment.ampl_microwaves = dB_to_V(self.experiment.p_microwaves)
             self.experiment.ampl_AOM_A1 = dB_to_V(self.experiment.p_AOM_A1)
@@ -398,7 +398,7 @@ class BaseExperiment:
                 experiment=self.experiment,
                 device_aliases=[
                     'dds_FORT',
-                    'dds_D1_pumping_SP',
+                    'dds_D1_pumping_DP',
                     'dds_cooling_DP',
                     'dds_pumping_repump',
                     'dds_excitation',
@@ -468,7 +468,7 @@ class BaseExperiment:
                 experiment=self.experiment,
                 device_aliases=[
                     'dds_FORT',
-                    'dds_D1_pumping_SP',
+                    'dds_D1_pumping_DP',
                     'dds_cooling_DP',
                     'dds_pumping_repump',
                     'dds_excitation',
@@ -538,7 +538,7 @@ class BaseExperiment:
                 experiment=self.experiment,
                 device_aliases=[
                     'dds_FORT',
-                    'dds_D1_pumping_SP',
+                    'dds_D1_pumping_DP',
                     'dds_cooling_DP',
                     'dds_pumping_repump',
                     'dds_excitation',

--- a/utilities/config/alice/device_aliases.json
+++ b/utilities/config/alice/device_aliases.json
@@ -1,7 +1,7 @@
 { "ALIAS_MAP": {
   "dds_FORT": "urukul0_ch0",
   "dds_cooling_DP": "urukul0_ch1",
-  "dds_D1_pumping_SP": "urukul2_ch2",
+  "dds_D1_pumping_DP": "urukul2_ch2",
   "dds_pumping_repump": "urukul0_ch2",
   "dds_AOM_A2": "urukul1_ch0",
   "dds_AOM_A3": "urukul1_ch1",
@@ -21,9 +21,9 @@
       "frequency": "f_cooling_DP_MOT",
       "power": "p_cooling_DP_MOT"
     },
-    "dds_D1_pumping_SP": {
-      "frequency": "f_D1_pumping_SP",
-      "power": "p_D1_pumping_SP"
+    "dds_D1_pumping_DP": {
+      "frequency": "f_D1_pumping_DP",
+      "power": "p_D1_pumping_DP"
     },
     "dds_pumping_repump": {
       "frequency": "f_pumping_repump",

--- a/utilities/config/alice/feedback_channels.json
+++ b/utilities/config/alice/feedback_channels.json
@@ -90,7 +90,7 @@
         },
     "sampler1":
         {
-            "dds_D1_pumping_SP":
+            "dds_D1_pumping_DP":
                 {
                     "sampler_ch": 4,
                     "set_points": ["set_point_D1_SP"],
@@ -98,7 +98,7 @@
                     "i": 0.0,
                     "series": true,
                     "dataset":"D1_SP_monitor",
-                    "power_dataset":"p_D1_pumping_SP",
+                    "power_dataset":"p_D1_pumping_DP",
                     "t_measure_delay":0.00001,
                     "max_dB": -5
                 }

--- a/utilities/config/alice/feedback_channels_FORT_APD.json
+++ b/utilities/config/alice/feedback_channels_FORT_APD.json
@@ -90,7 +90,7 @@
         },
     "sampler1":
         {
-            "dds_D1_pumping_SP":
+            "dds_D1_pumping_DP":
                 {
                     "sampler_ch": 4,
                     "set_points": ["set_point_D1_SP"],
@@ -98,7 +98,7 @@
                     "i": 0.0,
                     "series": true,
                     "dataset":"D1_SP_monitor",
-                    "power_dataset":"p_D1_pumping_SP",
+                    "power_dataset":"p_D1_pumping_DP",
                     "t_measure_delay":0.00001,
                     "max_dB": -5
                 }

--- a/utilities/config/alice/feedback_channels_FORT_uses_MM_fiber_monitor.json
+++ b/utilities/config/alice/feedback_channels_FORT_uses_MM_fiber_monitor.json
@@ -90,7 +90,7 @@
         },
     "sampler1":
         {
-            "dds_D1_pumping_SP":
+            "dds_D1_pumping_DP":
                 {
                     "sampler_ch": 4,
                     "set_points": ["set_point_D1_SP"],
@@ -98,7 +98,7 @@
                     "i": 0.0,
                     "series": true,
                     "dataset":"D1_SP_monitor",
-                    "power_dataset":"p_D1_pumping_SP",
+                    "power_dataset":"p_D1_pumping_DP",
                     "t_measure_delay":0.00001,
                     "max_dB": -5
                 }

--- a/utilities/config/bob/device_aliases.json
+++ b/utilities/config/bob/device_aliases.json
@@ -1,7 +1,7 @@
 { "ALIAS_MAP": {
   "dds_FORT": "urukul0_ch0",
   "dds_cooling_DP": "urukul0_ch1",
-  "dds_D1_pumping_SP": "urukul2_ch2",
+  "dds_D1_pumping_DP": "urukul2_ch2",
   "dds_pumping_repump": "urukul0_ch2",
   "dds_AOM_A2": "urukul1_ch0",
   "dds_AOM_A3": "urukul1_ch1",
@@ -21,9 +21,9 @@
       "frequency": "f_cooling_DP_MOT",
       "power": "p_cooling_DP_MOT"
     },
-    "dds_D1_pumping_SP": {
-      "frequency": "f_D1_pumping_SP",
-      "power": "p_D1_pumping_SP"
+    "dds_D1_pumping_DP": {
+      "frequency": "f_D1_pumping_DP",
+      "power": "p_D1_pumping_DP"
     },
     "dds_pumping_repump": {
       "frequency": "f_pumping_repump",

--- a/utilities/config/bob/feedback_channels.json
+++ b/utilities/config/bob/feedback_channels.json
@@ -89,7 +89,7 @@
         },
     "sampler1":
         {
-            "dds_D1_pumping_SP":
+            "dds_D1_pumping_DP":
                 {
                     "sampler_ch": 4,
                     "set_points": ["set_point_D1_SP"],
@@ -97,7 +97,7 @@
                     "i": 0.0,
                     "series": true,
                     "dataset":"D1_SP_monitor",
-                    "power_dataset":"p_D1_pumping_SP",
+                    "power_dataset":"p_D1_pumping_DP",
                     "t_measure_delay":0.00001,
                     "max_dB": -5
                 }

--- a/utilities/config/two_nodes/device_aliases.json
+++ b/utilities/config/two_nodes/device_aliases.json
@@ -1,7 +1,7 @@
 { "ALIAS_MAP": {
   "dds_FORT": "urukul0_ch0",
   "dds_cooling_DP": "urukul0_ch1",
-  "dds_D1_pumping_SP": "urukul2_ch2",
+  "dds_D1_pumping_DP": "urukul2_ch2",
   "dds_pumping_repump": "urukul0_ch2",
   "dds_AOM_A2": "urukul1_ch0",
   "dds_AOM_A3": "urukul1_ch1",
@@ -21,9 +21,9 @@
       "frequency": "f_cooling_DP_MOT",
       "power": "p_cooling_DP_MOT"
     },
-    "dds_D1_pumping_SP": {
-      "frequency": "f_D1_pumping_SP",
-      "power": "p_D1_pumping_SP"
+    "dds_D1_pumping_DP": {
+      "frequency": "f_D1_pumping_DP",
+      "power": "p_D1_pumping_DP"
     },
     "dds_pumping_repump": {
       "frequency": "f_pumping_repump",

--- a/utilities/config/two_nodes/feedback_channels.json
+++ b/utilities/config/two_nodes/feedback_channels.json
@@ -89,7 +89,7 @@
         },
     "sampler1":
         {
-            "dds_D1_pumping_SP":
+            "dds_D1_pumping_DP":
                 {
                     "sampler_ch": 4,
                     "set_points": ["set_point_D1_SP"],
@@ -97,7 +97,7 @@
                     "i": 0.0,
                     "series": true,
                     "dataset":"D1_SP_monitor",
-                    "power_dataset":"p_D1_pumping_SP",
+                    "power_dataset":"p_D1_pumping_DP",
                     "t_measure_delay":0.00001,
                     "max_dB": -5
                 }


### PR DESCRIPTION
Variable references to the D1 single pass (SP) have been renamed to refer to the D1 double pass (DP), which is now what is controlled by the relevant urukul channel. Note that while there are two D1 DP AOMs in the lab, only one is controlled by ARTIQ for now. This will be the case until we free up or add more urukul channels.